### PR TITLE
Split bsp.rb into ./csgtool.rb and ./lib/csg.rb

### DIFF
--- a/csgtool.rb
+++ b/csgtool.rb
@@ -3,18 +3,10 @@ require './lib/csg'
 object = CSG::Solid.new(:file => ARGV[0])
 object2 = CSG::Solid.new(:file => ARGV[1])
 
-object_bsp = object.tree
-object2_bsp = object2.tree
-
-#intersect_bsp = CSG::Native::BSPNode.new( CSG::Native.bsp_intersect(object_bsp, object2_bsp) )
 intersect = object.intersect(object2)
 subtract = object.subtract(object2)
 union = object.union(object2)
 
-i = intersect.to_stl
-s = subtract.to_stl
-u = union.to_stl
-
-CSG::Native.stl_write_file(u, "union.stl")
-CSG::Native.stl_write_file(s, "substract.stl")
-CSG::Native.stl_write_file(i, "intersect.stl")
+intersect.to_stl.write_file "intersect.stl"
+subtract.to_stl.write_file "subtract.stl"
+union.to_stl.write_file "union.stl"

--- a/lib/csg.rb
+++ b/lib/csg.rb
@@ -13,6 +13,10 @@ module CSG
       def self.release(ptr)
         CSG::Native.stl_free ptr
       end
+
+      def write_file(path)
+        CSG::Native.stl_write_file self, path
+      end
     end
 
     class BSPNode < FFI::ManagedStruct


### PR DESCRIPTION
Slightly prepare the binding to be more like Ruby and less like C.
## Things
- [x] Split the driver and library
- [x] wrap operation in a `Solid` class
- [x] Update driver to not use the `CSG::Native` API

**Targets #24**

cc/ @sbryant 
