### PR TITLE
A "try to stay on the stack" optimization for bsp_clip_polygons/_array

### DIFF
--- a/src/bsp.c
+++ b/src/bsp.c
@@ -307,7 +307,8 @@ klist_t(poly) *bsp_clip_polygon_array(bsp_node_t *node, poly_t **polygons, size_
 	poly_t *p = NULL;
 	int rc = -1;
 
-	poly_t **poly_buffer = NULL;
+	poly_t *static_poly_buffer[STATIC_POLY_BUFFER_SIZE];
+	poly_t **poly_buffer = static_poly_buffer;
 	poly_t **front_array = NULL;
 	poly_t **back_array = NULL;
 	int n_front = 0;
@@ -317,7 +318,9 @@ klist_t(poly) *bsp_clip_polygon_array(bsp_node_t *node, poly_t **polygons, size_
 	if(n_polys == 0) return result;
 
 	if(node->divider != NULL) {
-		check_mem(poly_buffer = malloc((sizeof(poly_t*) * n_polys) * 2));
+		if((n_polys * 2) > STATIC_POLY_BUFFER_SIZE) {
+			check_mem(poly_buffer = malloc((sizeof(poly_t*) * n_polys) * 2));
+		}
 		front_array = poly_buffer;
 		back_array = poly_buffer + n_polys;
 		// Sort this node's polygons into the front or back
@@ -350,7 +353,7 @@ klist_t(poly) *bsp_clip_polygon_array(bsp_node_t *node, poly_t **polygons, size_
 			check(result != NULL, "Failed to clip back tree");
 		}
 
-		if(poly_buffer) free(poly_buffer);
+		if(poly_buffer != static_poly_buffer) free(poly_buffer);
 		// Clean up the result halves, now that they're copied into `result`
 	}
 	else {
@@ -363,7 +366,7 @@ klist_t(poly) *bsp_clip_polygon_array(bsp_node_t *node, poly_t **polygons, size_
 
 	return result;
 error:
-	if(poly_buffer) free(poly_buffer);
+	if(poly_buffer != static_poly_buffer) free(poly_buffer);
 	if(result) kl_destroy(poly, result);
 	return NULL;
 }
@@ -374,7 +377,8 @@ klist_t(poly) *bsp_clip_polygons(bsp_node_t *node, klist_t(poly) *polygons, klis
 	poly_t *p = NULL;
 	int rc = -1;
 
-	poly_t **poly_buffer = NULL;
+	poly_t *static_poly_buffer[STATIC_POLY_BUFFER_SIZE];
+	poly_t **poly_buffer = static_poly_buffer;
 	poly_t **front_array = NULL;
 	poly_t **back_array = NULL;
 	int n_front = 0;
@@ -384,7 +388,9 @@ klist_t(poly) *bsp_clip_polygons(bsp_node_t *node, klist_t(poly) *polygons, klis
 	if(polygons->size == 0) return result;
 
 	if(node->divider != NULL) {
-		check_mem(poly_buffer = malloc(sizeof(poly_t*) * polygons->size * 2));
+		if((polygons->size * 2) > STATIC_POLY_BUFFER_SIZE) {
+			check_mem(poly_buffer = malloc(sizeof(poly_t*) * polygons->size * 2));
+		}
 		front_array = poly_buffer;
 		back_array = poly_buffer + polygons->size;
 		// Sort this node's polygons into the front or back
@@ -416,7 +422,7 @@ klist_t(poly) *bsp_clip_polygons(bsp_node_t *node, klist_t(poly) *polygons, klis
 			check(result != NULL, "Failed to clip back tree");
 		}
 
-		if(poly_buffer) free(poly_buffer);
+		if(poly_buffer != static_poly_buffer) free(poly_buffer);
 		// Clean up the result halves, now that they're copied into `result`
 	}
 	else {
@@ -429,7 +435,7 @@ klist_t(poly) *bsp_clip_polygons(bsp_node_t *node, klist_t(poly) *polygons, klis
 
 	return result;
 error:
-	if(poly_buffer) free(poly_buffer);
+	if(poly_buffer != static_poly_buffer) free(poly_buffer);
 	if(result) kl_destroy(poly, result);
 	return NULL;
 }

--- a/src/bsp.h
+++ b/src/bsp.h
@@ -4,6 +4,17 @@
 #ifndef __BSP_H
 #define __BSP_H
 
+// This many polygon pointers are allocated
+// on the stack during bsp_clip_polygons and bsp_clip_polygon_array
+// Only when more than this is requested do we reach
+// into the heap for more polygon pointers.
+// Setting this to zero disables the optimization.
+// Exceptionally large values will limit the recursion
+// limit.
+#ifndef STATIC_POLY_BUFFER_SIZE
+#define STATIC_POLY_BUFFER_SIZE 200
+#endif
+
 typedef struct s_bsp_node {
 	klist_t(poly) *polygons;
 	poly_t *divider;


### PR DESCRIPTION
This saves us about a second of runtime on my machine in testing, and removes the entire `malloc/free` hotspot in the clipping functions in Instruments in the majority of cases.

Tunable by `#define STATIC_POLY_BUFFER_SIZE` in `bsp.h`
