### PR TITLE
Don't crash and panic if we have a zero-poly geometry

### DIFF
--- a/src/bsp.c
+++ b/src/bsp.c
@@ -24,8 +24,13 @@ bsp_node_t *clone_bsp_tree(bsp_node_t *tree) {
 	}
 
 	free_poly(copy->divider, 1);
-	copy->divider = clone_poly(tree->divider);
-	check_mem(copy->divider);
+	if(tree->divider) {
+		copy->divider = clone_poly(tree->divider);
+		check_mem(copy->divider);
+	}
+	else {
+		copy->divider = NULL;
+	}
 
 	if(tree->front != NULL) {
 		copy->front = clone_bsp_tree(tree->front);

--- a/src/stl.c
+++ b/src/stl.c
@@ -220,7 +220,6 @@ stl_object *stl_read_object(int fd) {
 		// Triangle count
 		rc = read(fd, &n_tris, sizeof(n_tris));
 		check(rc == sizeof(n_tris), "Failed to read facet count.");
-		check(n_tris > 0, "Facet count cannot be zero.");
 
 		obj = stl_alloc(header, n_tris);
 


### PR DESCRIPTION
Kill the check for a facet count in `stl_read()` and be more cautious during `bsp_clone` to avoid trying to memcpy a NULL pointer from `tree->divider` which is not set in zero-poly geometries.
