### PR TITLE
Add license to gemspec

### DIFF
--- a/csg.gemspec
+++ b/csg.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.authors     = ["Yaroslav Shirokov", "Sean Bryant"]
   s.email       = ['sshirokov@github.com', 'sbryant@github.com']
+  s.license     = 'MIT'
   s.files       = ["Makefile", "lib/csg.rb"] + Dir['src/**/*.{c,h}']
   s.homepage    = 'https://github.com/sshirokov/csgtool/'
   s.add_runtime_dependency 'ffi'


### PR DESCRIPTION
We have the MIT License file, this just specifies it in the gemspec as well.

Fixes #47
