### PR TITLE
Implement a clamp on the LERP alpha val

### DIFF
--- a/src/poly.c
+++ b/src/poly.c
@@ -320,6 +320,7 @@ int poly_split(poly_t *divider, poly_t *poly, poly_t **front, poly_t **back) {
 			float t = divider->w;
 			t = t - f3_dot(divider->normal, v_cur);
 			t = t / f3_dot(divider->normal, diff);
+			t = clampf(t, 0.0, 1.0);
 
 			float3 mid_f = {v_cur[0], v_cur[1], v_cur[2]};
 			f3_interpolate(&mid_f, v_cur, v_next, t);

--- a/src/util.c
+++ b/src/util.c
@@ -136,3 +136,9 @@ char *next_line(FILE *f, bool downcase, bool trim) {
 
 	return line;
 }
+
+float clampf(float val, float min, float max) {
+	if(val > max) return max;
+	if(val < min) return min;
+	return val;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -31,4 +31,6 @@ char *read_line(FILE *f, bool downcase, bool trim);
 // Gets the "next" non-blank line
 char *next_line(FILE *f, bool downcase, bool trim);
 
+float clampf(float val, float min, float max);
+
 #endif


### PR DESCRIPTION
Prevent the LERP alpha from leaving the [0, 1] range, which prevents
polygons from growing super-long edges.

In my testing, this appears to **eliminate** out of bounds artifacting during BSP construction 

Original stl analysis:

```
~/src/csgtool$ stltwalker -R -r -I hard-old.stl
[INFO] (src/stltwalker.c:181) Raw out is now ON
[INFO] (src/stltwalker.c:176) Raw load is now ON
[INFO] (src/stltwalker.c:171) Setting memcopy collection mode.
[INFO] (/Users/yshirokov/src/self/stltwalker/src/stl.c:173) Header: [[STL/ASCII]: 'solid ascii']
[INFO] (/Users/yshirokov/src/self/stltwalker/src/stl.c:186) ASCII solid ended. Loaded 2326 facets
[INFO] (src/stltwalker.c:210) NOT Centering 'hard-old.stl'
[INFO] (src/stltwalker.c:217) hard-old.stl center: (-125.000000, 151.000000, 20.250000). Size: 43.000000x18.000000x39.500000
```

BSP geometric identity stl analysis

```
~/src/csgtool$ stltwalker -R -r -I hard-old.stl.bsp.stl 
[INFO] (src/stltwalker.c:181) Raw out is now ON
[INFO] (src/stltwalker.c:176) Raw load is now ON
[INFO] (src/stltwalker.c:171) Setting memcopy collection mode.
[INFO] (/Users/yshirokov/src/self/stltwalker/src/stl.c:224) Expecting to read 69818 triangles.
[INFO] (src/stltwalker.c:210) NOT Centering 'hard-old.stl.bsp.stl'
[INFO] (src/stltwalker.c:217) hard-old.stl.bsp.stl center: (-125.000000, 151.000000, 20.250000). Size: 43.000000x18.000000x39.500000
```

Which also seems visually sane. :sparkles: :tada: :gun: 
