### PR TITLE
src/stl: fd_stat.st_size can be a long long.

### DIFF
--- a/src/stl.c
+++ b/src/stl.c
@@ -197,8 +197,8 @@ stl_object *stl_read_object(int fd) {
 
 		// Do we have a file that supports that size?
 		check(fd_stat.st_size == req_size,
-			  "File at fd(%d) is %zd bytes, needs to be %zd bytes for %u facets.",
-			  fd, fd_stat.st_size, req_size, n_tris);
+			  "File at fd(%d) is %lld bytes, needs to be %zd bytes for %u facets.",
+			  fd, (long long)fd_stat.st_size, req_size, n_tris);
 
 		// Allocate space for the object we know we can hold
 		obj = stl_alloc(header, n_tris);


### PR DESCRIPTION
This is the case on macOS 10.14 Mojave so cast places with smaller values and adjust the formatting string accordingly.