### PR TITLE
Bump Ruby Version

### DIFF
--- a/csg.gemspec
+++ b/csg.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'csg'
-  s.version = '0.1.5'
+  s.version = '0.1.6'
   s.summary     = "A fast library for Constructive Solid Geometry"
   s.description = s.summary
   s.authors     = ["Yaroslav Shirokov", "Sean Bryant"]


### PR DESCRIPTION
Bumps the ruby version for a new release with https://github.com/sshirokov/csgtool/pull/64